### PR TITLE
feat: reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-bullseye as base
+FROM python:3.7-slim as base
 
 WORKDIR /app
 COPY requirements.txt /app/requirements.txt


### PR DESCRIPTION
`make test` for `slim` and `bullseye`

```
$ docker image ls
REPOSITORY                            TAG            IMAGE ID       CREATED          SIZE
yoinkbird/cs_modelgen_test-slim       latest         e4eb160fb01e   51 seconds ago   564MB
yoinkbird/cs_modelgen_test-bullseye   latest         df2b847df3cf   2 minutes ago    1.35GB

python                                3.7-slim       7ef53f615a8b   3 days ago       123MB
python                                3.7-bullseye   fd433822517a   3 days ago       909MB
```

Analyse with [dive](https://github.com/wagoodman/dive#ci-integration):
```
$ CI=true dive yoinkbird/cs_modelgen_test-slim
  Using default CI config
Image Source: docker://yoinkbird/cs_modelgen_test-slim
Fetching image... (this can take a while for large images)
Analyzing image...
  efficiency: 99.0996 %
  wastedBytes: 6862885 bytes (6.9 MB)
  userWastedPercent: 1.4200 %
```

Wasting 7 MB is probably acceptable